### PR TITLE
Add option identity via `?`

### DIFF
--- a/src/unary/try_option.rs
+++ b/src/unary/try_option.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub fn try_option(x: Option<i32>) -> Option<i32> {
+    Some(x?)
+}


### PR DESCRIPTION
Needs ?-on-Option, which is currently in beta for release in <3 weeks: https://play.rust-lang.org/?gist=c90f10da4cbe91d26f9667a48c232a8e&version=beta&mode=release

This is similar to `try.rs`, but more difficult because the `?` desugaring always goes through result.